### PR TITLE
Fix PCRE_VERSION comparison when the version has a timestamp

### DIFF
--- a/Grapheme.php
+++ b/Grapheme.php
@@ -11,7 +11,11 @@
 
 namespace Symfony\Polyfill\Intl\Grapheme;
 
-\define('SYMFONY_GRAPHEME_CLUSTER_RX', \PCRE_VERSION >= '8.32' ? '\X' : Grapheme::GRAPHEME_CLUSTER_RX);
+if (version_compare(\PCRE_VERSION, '8.32', '>=')) {
+    \define('SYMFONY_GRAPHEME_CLUSTER_RX', '\X');
+} else {
+    \define('SYMFONY_GRAPHEME_CLUSTER_RX', Grapheme::GRAPHEME_CLUSTER_RX);
+}
 
 /**
  * Partial intl implementation in pure PHP.


### PR DESCRIPTION
PCRE_VERSION constant might (or always) contains the date, as in: `MAJOR.MINOR Y-m-d`, or `10.35 2020-05-09`, refer to https://www.php.net/manual/en/pcre.constants.php

This PR fixes the version compare to account for the date, according to these tests:

- Before, notice that `10.35 2020-05-09` is considered lower than `8.32`: https://3v4l.org/imMSe#v8.0.10
- After: https://3v4l.org/IfSJi#v8.0.10